### PR TITLE
fix: incomplete configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
 
+.venv/
+
 *.log
 
 .backup/

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,3 +2,6 @@
 disable=
     E0401, # import-error
     W0603, # global-statement
+
+[FORMAT]
+max-line-length=120

--- a/env/.env.sample
+++ b/env/.env.sample
@@ -7,12 +7,13 @@ DB_NAME=
 
 # URLs that should be checked (including a description);
 # Create one combination of URL_TO_CHECKX and URL_DESCRIPTIONX, with the X being a sequential number
-URL_TO_CHECK1=
+# URLs should be in quotes
+URL_TO_CHECK1=""
 URL_DESCRIPTION1=
 #URL_TO_CHECK2=
 #URL_DESCRIPTION2=
 
-# The Slack webhook 
+# The Slack webhook
 SLACK_HOOK_URL=
 
 # Whether or not a message should be posted to the Slack webhook at each check (noisy)

--- a/main.py
+++ b/main.py
@@ -225,12 +225,15 @@ def prepare_and_post_message_to_slack(
         return
 
     color = CONST_GRAY
+    header_text = "Updates to Rivian Configurations"
     if status_code == 200:
         color = CONST_ORANGE
     elif status_code == 201:
         color = CONST_GREEN
+        header_text = "New Rivian Configurations"
     elif status_code == 500:
         color = CONST_RED
+        header_text = "Error retrieving Rivian configurations"
 
     message = {
         "attachments": [{
@@ -241,7 +244,7 @@ def prepare_and_post_message_to_slack(
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Rivian Configurations Update" if status_code == 200 else "Rivian Configurations Error"
+                        "text": header_text
                     }
                 },
                 {

--- a/main.py
+++ b/main.py
@@ -127,10 +127,10 @@ def get_config_data(config: str):
         "Vehicle": configs[0],
         "Motor/Battery": configs[1],
         "Price": configs[2],
-        "Wheels": configs[wheels_index],
-        "Interior": configs[wheels_index + 1],
-        "Exterior": configs[wheels_index + 2],
-        "Packages": ", ".join(configs[(wheels_index + 3):])
+        "Wheels": configs[wheels_index] if wheels_index > 0 else "Incomplete",
+        "Interior": configs[wheels_index + 1] if wheels_index > 0 else "Incomplete",
+        "Exterior": configs[wheels_index + 2] if wheels_index > 0 else "Incomplete",
+        "Packages": ", ".join(configs[(wheels_index + 3):] if wheels_index > 0 else ["Incomplete"])
     }
 
 


### PR DESCRIPTION
**ISSUE:** #3 , #4 , #7 

**DESCRIPTION:** Sometimes, configurations are retrieved incomplete, but there is no way to mitigate that at the source. This leads to multiple updates being applied. The workaround is to evaluate configurations for equality by comparing only the first three field (usually sufficient) when there is incomplete data present, or do a deep compare is there is no incomplete data.
Additionally created links to URLs in messages and fixed color coding of message.

**TESTING:** It was manually tested for positive cases, but now waiting for when the website actually returns incomplete data to verify negative case.

**CONTEXT:** N/A.
